### PR TITLE
docs(readme): use process.pid in OpenCode server integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,12 @@ import type { Plugin } from "@opencode-ai/plugin"
 export const DingDing: Plugin = async ({ $ }) => ({
   event: async ({ event }) => {
     if (event.type === "session.idle") {
-      await $`curl -s localhost:8228/notify -d '{"agent":"opencode","body":"Task finished","pid":'$$'}'`
+      const payload = JSON.stringify({
+        agent: "opencode",
+        body: "Task finished",
+        pid: process.pid,
+      })
+      await $`curl -s localhost:8228/notify -H "Content-Type: application/json" -d ${payload}`
     }
   },
 })


### PR DESCRIPTION
## Summary
- update the OpenCode TypeScript server-mode plugin example to pass `pid` via `process.pid` instead of shell `$$` interpolation
- build the JSON payload in TypeScript and send it with `Content-Type: application/json` for clearer, more reliable `/notify` requests
- keep release workflow untouched by including `[skip release]` in the commit message

## Testing
- not run (docs-only change)