### PR TITLE
fix(notifier): prevent duplicate forced pushes and add --test-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,18 @@ ding-ding notify Task completed successfully
 # Pipe output
 echo "tests passed" | ding-ding notify
 
-# Force push (ignore idle check, always send to ntfy/Discord/webhook)
+# Force push (always send remote push, even if focused/active)
 ding-ding notify -p -m "Deploy complete"
+
+# Force local/system notification even when focused suppression would mute it
+ding-ding notify --test-local -m "Testing local notification"
+
+# Force both local/system and remote push
+ding-ding notify -p --test-local -m "Test all channels"
 ```
+
+`--push` only affects remote push backends (ntfy/Discord/webhook). It does not
+implicitly force a local/system notification; use `--test-local` for that.
 
 ### HTTP Server
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,8 +14,10 @@ var rootCmd = &cobra.Command{
 	Short: "Agent completion notifications",
 	Long: `ding-ding sends notifications when AI agents (Claude, opencode, etc.) finish tasks.
 
-It shows a system notification immediately, and if you're away from your
-computer (idle), it also pushes via ntfy, Discord, or custom webhooks.
+It uses attention-aware 3-tier notifications:
+- focused and active: quiet
+- active but unfocused: system notification
+- idle: system notification + push via ntfy, Discord, or webhooks.
 
 Usage:
   ding-ding notify -m "Task completed"    Send a notification via CLI


### PR DESCRIPTION
## Summary
- route `notify` through a unified `NotifyWithOptions` path to prevent duplicate push sends when `--push` is used
- add `--test-local` to force system/local notifications for testing while keeping `--push` as remote-force behavior
- align CLI/docs text with 3-tier focus-aware behavior and add regression tests for force flag combinations and error propagation

## Testing
- go test ./...