### PR TITLE
feat(agent): add setup commands and harden Claude hook upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,33 @@ ding-ding notify -p --test-local -m "Test all channels"
 `--push` only affects remote push backends (ntfy/Discord/webhook). It does not
 implicitly force a local/system notification; use `--test-local` for that.
 
+### Agent Setup
+
+```bash
+# Initialize (or upsert) Claude project hooks using CLI mode
+ding-ding agent init claude project
+
+# Initialize (or upsert) OpenCode global plugin using CLI mode
+ding-ding agent init opencode global
+
+# Update Claude global hooks to server mode templates
+ding-ding agent update claude global --mode server
+
+# Update OpenCode project plugin in server mode
+ding-ding agent update opencode project --mode server
+```
+
+Command shape:
+
+```bash
+ding-ding agent init <agent> <scope> [--mode cli|server]
+ding-ding agent update <agent> <scope> [--mode cli|server]
+```
+
+- Supported agents: `claude`, `opencode`
+- Supported scopes: `project`, `global`
+- Default mode: `cli`
+
 ### HTTP Server
 
 ```bash
@@ -77,7 +104,15 @@ curl "localhost:8228/notify?message=done&agent=claude"
 
 #### Claude Code
 
-Add to `.claude/settings.json` (project) or `~/.claude/settings.json` (global):
+Use the setup command (recommended):
+
+```bash
+ding-ding agent init claude project
+# or
+ding-ding agent init claude global
+```
+
+Manual setup if needed. Add to `.claude/settings.json` (project) or `~/.claude/settings.json` (global):
 
 **Option A: CLI with async hook (simplest)**
 ```json
@@ -151,7 +186,15 @@ Start the server separately with `ding-ding serve`.
 
 #### OpenCode
 
-OpenCode uses TypeScript plugins. Save as `.opencode/plugins/ding-ding.ts`:
+Use the setup command (recommended):
+
+```bash
+ding-ding agent init opencode project
+# or
+ding-ding agent init opencode global
+```
+
+Manual setup if needed. OpenCode uses TypeScript plugins. Save as `.opencode/plugins/ding-ding.ts`:
 
 **Option A: CLI**
 ```typescript

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Digni/ding-ding/internal/agentsetup"
+	"github.com/spf13/cobra"
+)
+
+var (
+	agentMode   string
+	agentUpsert = agentsetup.Upsert
+)
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Manage agent integrations",
+}
+
+var agentInitCmd = &cobra.Command{
+	Use:   "init <agent> <scope>",
+	Short: "Initialize agent hooks/plugins",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runAgentConfigure,
+}
+
+var agentUpdateCmd = &cobra.Command{
+	Use:   "update <agent> <scope>",
+	Short: "Update agent hooks/plugins",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runAgentConfigure,
+}
+
+func runAgentConfigure(cmd *cobra.Command, args []string) error {
+	agent, err := agentsetup.ParseAgent(args[0])
+	if err != nil {
+		return err
+	}
+	scope, err := agentsetup.ParseScope(args[1])
+	if err != nil {
+		return err
+	}
+	mode, err := agentsetup.ParseMode(agentMode)
+	if err != nil {
+		return err
+	}
+
+	result, err := agentUpsert(agentsetup.Options{
+		Agent: agent,
+		Scope: scope,
+		Mode:  mode,
+	})
+	if err != nil {
+		return fmt.Errorf("configure %s (%s): %w", agent, scope, err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "configured %s (%s, mode=%s): %s [%s]\n", agent, scope, mode, result.Path, result.Status)
+	return nil
+}
+
+func init() {
+	agentCmd.PersistentFlags().StringVar(&agentMode, "mode", string(agentsetup.ModeCLI), "Integration mode: cli or server")
+	agentCmd.AddCommand(agentInitCmd)
+	agentCmd.AddCommand(agentUpdateCmd)
+	rootCmd.AddCommand(agentCmd)
+}

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Digni/ding-ding/internal/agentsetup"
+	"github.com/spf13/cobra"
+)
+
+func TestAgentInitAndUpdateBothUseUpsert(t *testing.T) {
+	origUpsert := agentUpsert
+	origMode := agentMode
+	defer func() {
+		agentUpsert = origUpsert
+		agentMode = origMode
+	}()
+
+	agentMode = string(agentsetup.ModeCLI)
+	calls := 0
+	agentUpsert = func(opts agentsetup.Options) (agentsetup.Result, error) {
+		calls++
+		if opts.Agent != agentsetup.AgentClaude {
+			t.Fatalf("opts.Agent = %q, want %q", opts.Agent, agentsetup.AgentClaude)
+		}
+		if opts.Scope != agentsetup.ScopeProject {
+			t.Fatalf("opts.Scope = %q, want %q", opts.Scope, agentsetup.ScopeProject)
+		}
+		if opts.Mode != agentsetup.ModeCLI {
+			t.Fatalf("opts.Mode = %q, want %q", opts.Mode, agentsetup.ModeCLI)
+		}
+		return agentsetup.Result{
+			Path:   "/tmp/path",
+			Status: agentsetup.StatusUpdated,
+		}, nil
+	}
+
+	for _, c := range []*cobra.Command{agentInitCmd, agentUpdateCmd} {
+		var stdout bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&stdout)
+
+		if err := c.RunE(cmd, []string{"claude", "project"}); err != nil {
+			t.Fatalf("RunE returned error: %v", err)
+		}
+		if !strings.Contains(stdout.String(), "configured claude (project, mode=cli): /tmp/path [updated]") {
+			t.Fatalf("unexpected output %q", stdout.String())
+		}
+	}
+
+	if calls != 2 {
+		t.Fatalf("upsert calls = %d, want 2", calls)
+	}
+}
+
+func TestAgentRunE_InvalidAgent(t *testing.T) {
+	err := runAgentConfigure(&cobra.Command{}, []string{"unknown", "project"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid agent") {
+		t.Fatalf("error %q does not contain %q", err, "invalid agent")
+	}
+}
+
+func TestAgentRunE_InvalidScope(t *testing.T) {
+	err := runAgentConfigure(&cobra.Command{}, []string{"claude", "workspace"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid scope") {
+		t.Fatalf("error %q does not contain %q", err, "invalid scope")
+	}
+}
+
+func TestAgentRunE_InvalidMode(t *testing.T) {
+	origMode := agentMode
+	defer func() { agentMode = origMode }()
+	agentMode = "bad"
+
+	err := runAgentConfigure(&cobra.Command{}, []string{"claude", "project"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid mode") {
+		t.Fatalf("error %q does not contain %q", err, "invalid mode")
+	}
+}
+
+func TestAgentRunE_ServerModePassesThrough(t *testing.T) {
+	origUpsert := agentUpsert
+	origMode := agentMode
+	defer func() {
+		agentUpsert = origUpsert
+		agentMode = origMode
+	}()
+
+	agentMode = string(agentsetup.ModeServer)
+	agentUpsert = func(opts agentsetup.Options) (agentsetup.Result, error) {
+		if opts.Mode != agentsetup.ModeServer {
+			t.Fatalf("opts.Mode = %q, want %q", opts.Mode, agentsetup.ModeServer)
+		}
+		return agentsetup.Result{
+			Path:   "/tmp/server",
+			Status: agentsetup.StatusCreated,
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+
+	if err := runAgentConfigure(cmd, []string{"opencode", "global"}); err != nil {
+		t.Fatalf("runAgentConfigure returned error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "configured opencode (global, mode=server): /tmp/server [created]") {
+		t.Fatalf("unexpected output %q", stdout.String())
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,8 @@ It uses attention-aware 3-tier notifications:
 Usage:
   ding-ding notify -m "Task completed"    Send a notification via CLI
   ding-ding serve                         Start HTTP server for agent POSTs
-  ding-ding config init                   Create default config file`,
+  ding-ding config init                   Create default config file
+  ding-ding agent init claude project     Install agent integration hooks`,
 }
 
 func Execute() {

--- a/internal/agentsetup/claude.go
+++ b/internal/agentsetup/claude.go
@@ -1,0 +1,180 @@
+package agentsetup
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	claudeEventStop         = "Stop"
+	claudeEventNotification = "Notification"
+)
+
+func upsertClaudeSettings(path string, mode Mode) (ChangeStatus, error) {
+	existing, err := os.ReadFile(path)
+	fileExists := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("read claude settings %q: %w", path, err)
+	}
+
+	root := map[string]any{}
+	if fileExists {
+		if err := json.Unmarshal(existing, &root); err != nil {
+			return "", fmt.Errorf("parse claude settings %q: %w", path, err)
+		}
+	}
+
+	if err := upsertClaudeHooks(root, mode); err != nil {
+		return "", fmt.Errorf("upsert claude hooks: %w", err)
+	}
+
+	data, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal claude settings: %w", err)
+	}
+	data = append(data, '\n')
+
+	if fileExists && bytes.Equal(existing, data) {
+		return StatusUnchanged, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create claude settings directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("write claude settings %q: %w", path, err)
+	}
+
+	if fileExists {
+		return StatusUpdated, nil
+	}
+	return StatusCreated, nil
+}
+
+func upsertClaudeHooks(root map[string]any, mode Mode) error {
+	hooksValue, ok := root["hooks"]
+	if !ok {
+		hooksValue = map[string]any{}
+		root["hooks"] = hooksValue
+	}
+
+	hooks, ok := hooksValue.(map[string]any)
+	if !ok {
+		return fmt.Errorf("expected hooks to be an object")
+	}
+
+	events := []string{claudeEventStop, claudeEventNotification}
+	for _, event := range events {
+		existingEvent := []any{}
+		if value, exists := hooks[event]; exists {
+			arr, ok := value.([]any)
+			if !ok {
+				return fmt.Errorf("expected hooks.%s to be an array", event)
+			}
+			existingEvent = arr
+		}
+
+		cleaned, err := removeManagedClaudeHooks(event, existingEvent)
+		if err != nil {
+			return err
+		}
+		hooks[event] = append(cleaned, canonicalClaudeEventHook(event, mode))
+	}
+
+	return nil
+}
+
+func removeManagedClaudeHooks(event string, entries []any) ([]any, error) {
+	cleanedEntries := make([]any, 0, len(entries))
+
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			cleanedEntries = append(cleanedEntries, entry)
+			continue
+		}
+
+		hooksValue, hasHooks := entryMap["hooks"]
+		if !hasHooks {
+			cleanedEntries = append(cleanedEntries, entryMap)
+			continue
+		}
+
+		hookList, ok := hooksValue.([]any)
+		if !ok {
+			return nil, fmt.Errorf("expected hooks.%s[].hooks to be an array", event)
+		}
+
+		filteredHooks := make([]any, 0, len(hookList))
+		for _, hook := range hookList {
+			hookMap, ok := hook.(map[string]any)
+			if !ok {
+				filteredHooks = append(filteredHooks, hook)
+				continue
+			}
+
+			command, _ := hookMap["command"].(string)
+			if command != "" && isManagedClaudeCommand(command) {
+				continue
+			}
+			filteredHooks = append(filteredHooks, hookMap)
+		}
+
+		if len(filteredHooks) == 0 && mapHasOnlyKey(entryMap, "hooks") {
+			continue
+		}
+
+		entryMap["hooks"] = filteredHooks
+		cleanedEntries = append(cleanedEntries, entryMap)
+	}
+
+	return cleanedEntries, nil
+}
+
+func canonicalClaudeEventHook(event string, mode Mode) map[string]any {
+	return map[string]any{
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": claudeCommandForEvent(event, mode),
+				"async":   true,
+			},
+		},
+	}
+}
+
+func claudeCommandForEvent(event string, mode Mode) string {
+	switch mode {
+	case ModeServer:
+		if event == claudeEventNotification {
+			return `curl -s localhost:8228/notify -d '{"agent":"claude","body":"Needs your attention","pid":'$$'}'`
+		}
+		return `curl -s localhost:8228/notify -d '{"agent":"claude","body":"Task finished","pid":'$$'}'`
+	default:
+		if event == claudeEventNotification {
+			return "ding-ding notify -a claude -m 'Needs your attention'"
+		}
+		return "ding-ding notify -a claude -m 'Task finished'"
+	}
+}
+
+func isManagedClaudeCommand(command string) bool {
+	if strings.Contains(command, "ding-ding notify -a claude") {
+		return true
+	}
+
+	return strings.Contains(command, "localhost:8228/notify") &&
+		strings.Contains(command, `"agent":"claude"`)
+}
+
+func mapHasOnlyKey(value map[string]any, key string) bool {
+	if len(value) != 1 {
+		return false
+	}
+	_, ok := value[key]
+	return ok
+}

--- a/internal/agentsetup/claude_test.go
+++ b/internal/agentsetup/claude_test.go
@@ -1,0 +1,236 @@
+package agentsetup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpsertClaudeSettings_CreatesMinimalSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude", "settings.json")
+
+	status, err := upsertClaudeSettings(path, ModeCLI)
+	if err != nil {
+		t.Fatalf("upsertClaudeSettings() error = %v", err)
+	}
+	if status != StatusCreated {
+		t.Fatalf("status = %q, want %q", status, StatusCreated)
+	}
+
+	root := readJSONFile(t, path)
+	if _, ok := root["hooks"]; !ok {
+		t.Fatal("expected hooks object to be present")
+	}
+
+	stopCommands := eventCommands(t, root, claudeEventStop)
+	notificationCommands := eventCommands(t, root, claudeEventNotification)
+
+	assertContainsCommand(t, stopCommands, "ding-ding notify -a claude -m 'Task finished'")
+	assertContainsCommand(t, notificationCommands, "ding-ding notify -a claude -m 'Needs your attention'")
+}
+
+func TestUpsertClaudeSettings_MergesAndDeduplicatesManagedHooks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	seed := `{
+  "theme": "dark",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {"type": "command", "command": "echo keep-stop", "async": true},
+          {"type": "command", "command": "ding-ding notify -a claude -m 'old'", "async": true}
+        ]
+      },
+      {
+        "hooks": [
+          {"type": "command", "command": "ding-ding notify -a claude -m 'older'", "async": true}
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {"type": "command", "command": "echo keep-notification", "async": false}
+        ]
+      },
+      {
+        "hooks": [
+          {"type": "command", "command": "curl -s localhost:8228/notify -d '{\"agent\":\"claude\",\"body\":\"Task finished\",\"pid\":'$$'}'", "async": true}
+        ]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	status, err := upsertClaudeSettings(path, ModeCLI)
+	if err != nil {
+		t.Fatalf("upsertClaudeSettings() error = %v", err)
+	}
+	if status != StatusUpdated {
+		t.Fatalf("status = %q, want %q", status, StatusUpdated)
+	}
+
+	root := readJSONFile(t, path)
+	if got, _ := root["theme"].(string); got != "dark" {
+		t.Fatalf("theme = %q, want %q", got, "dark")
+	}
+
+	stopCommands := eventCommands(t, root, claudeEventStop)
+	notificationCommands := eventCommands(t, root, claudeEventNotification)
+
+	assertContainsCommand(t, stopCommands, "echo keep-stop")
+	assertContainsCommand(t, notificationCommands, "echo keep-notification")
+	assertContainsCommand(t, stopCommands, "ding-ding notify -a claude -m 'Task finished'")
+	assertContainsCommand(t, notificationCommands, "ding-ding notify -a claude -m 'Needs your attention'")
+
+	if countManagedCommands(stopCommands) != 1 {
+		t.Fatalf("Stop managed hook count = %d, want 1", countManagedCommands(stopCommands))
+	}
+	if countManagedCommands(notificationCommands) != 1 {
+		t.Fatalf("Notification managed hook count = %d, want 1", countManagedCommands(notificationCommands))
+	}
+}
+
+func TestUpsertClaudeSettings_ModeSwitchUpdatesCommands(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+
+	status, err := upsertClaudeSettings(path, ModeCLI)
+	if err != nil {
+		t.Fatalf("initial upsert error = %v", err)
+	}
+	if status != StatusCreated {
+		t.Fatalf("initial status = %q, want %q", status, StatusCreated)
+	}
+
+	status, err = upsertClaudeSettings(path, ModeServer)
+	if err != nil {
+		t.Fatalf("server upsert error = %v", err)
+	}
+	if status != StatusUpdated {
+		t.Fatalf("server status = %q, want %q", status, StatusUpdated)
+	}
+
+	root := readJSONFile(t, path)
+	stopCommands := eventCommands(t, root, claudeEventStop)
+	notificationCommands := eventCommands(t, root, claudeEventNotification)
+
+	assertContainsCommandWith(t, stopCommands, "curl -s localhost:8228/notify")
+	assertContainsCommandWith(t, stopCommands, `"agent":"claude"`)
+	assertContainsCommandWith(t, notificationCommands, "Needs your attention")
+}
+
+func TestUpsertClaudeSettings_InvalidJSONFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte("{ invalid json"), 0o644); err != nil {
+		t.Fatalf("write invalid file: %v", err)
+	}
+
+	_, err := upsertClaudeSettings(path, ModeCLI)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse claude settings") {
+		t.Fatalf("error = %q, want parse context", err)
+	}
+}
+
+func TestUpsertClaudeSettings_UnchangedWhenAlreadyCanonical(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+
+	if _, err := upsertClaudeSettings(path, ModeCLI); err != nil {
+		t.Fatalf("initial upsert error = %v", err)
+	}
+	status, err := upsertClaudeSettings(path, ModeCLI)
+	if err != nil {
+		t.Fatalf("second upsert error = %v", err)
+	}
+	if status != StatusUnchanged {
+		t.Fatalf("status = %q, want %q", status, StatusUnchanged)
+	}
+}
+
+func readJSONFile(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %q: %v", path, err)
+	}
+
+	root := map[string]any{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	return root
+}
+
+func eventCommands(t *testing.T, root map[string]any, event string) []string {
+	t.Helper()
+
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks is missing or not an object")
+	}
+	entries, ok := hooks[event].([]any)
+	if !ok {
+		t.Fatalf("hooks.%s is missing or not an array", event)
+	}
+
+	commands := make([]string, 0, 4)
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		hooksList, ok := entryMap["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, hook := range hooksList {
+			hookMap, ok := hook.(map[string]any)
+			if !ok {
+				continue
+			}
+			command, _ := hookMap["command"].(string)
+			if command != "" {
+				commands = append(commands, command)
+			}
+		}
+	}
+	return commands
+}
+
+func assertContainsCommand(t *testing.T, commands []string, want string) {
+	t.Helper()
+	for _, command := range commands {
+		if command == want {
+			return
+		}
+	}
+	t.Fatalf("commands %v do not contain exact %q", commands, want)
+}
+
+func assertContainsCommandWith(t *testing.T, commands []string, contains string) {
+	t.Helper()
+	for _, command := range commands {
+		if strings.Contains(command, contains) {
+			return
+		}
+	}
+	t.Fatalf("commands %v do not contain substring %q", commands, contains)
+}
+
+func countManagedCommands(commands []string) int {
+	count := 0
+	for _, command := range commands {
+		if isManagedClaudeCommand(command) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/agentsetup/opencode.go
+++ b/internal/agentsetup/opencode.go
@@ -1,0 +1,66 @@
+package agentsetup
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func upsertOpenCodePlugin(path string, mode Mode) (ChangeStatus, error) {
+	content := []byte(openCodePluginTemplate(mode))
+
+	existing, err := os.ReadFile(path)
+	fileExists := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("read opencode plugin %q: %w", path, err)
+	}
+
+	if fileExists && bytes.Equal(existing, content) {
+		return StatusUnchanged, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create opencode plugin directory: %w", err)
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return "", fmt.Errorf("write opencode plugin %q: %w", path, err)
+	}
+
+	if fileExists {
+		return StatusUpdated, nil
+	}
+	return StatusCreated, nil
+}
+
+func openCodePluginTemplate(mode Mode) string {
+	switch mode {
+	case ModeServer:
+		return `import type { Plugin } from "@opencode-ai/plugin"
+
+export const DingDing: Plugin = async ({ $ }) => ({
+  event: async ({ event }) => {
+    if (event.type === "session.idle") {
+      const payload = JSON.stringify({
+        agent: "opencode",
+        body: "Task finished",
+        pid: process.pid,
+      })
+      await $` + "`" + `curl -s localhost:8228/notify -H "Content-Type: application/json" -d ${payload}` + "`" + `
+    }
+  },
+})
+`
+	default:
+		return `import type { Plugin } from "@opencode-ai/plugin"
+
+export const DingDing: Plugin = async ({ $ }) => ({
+  event: async ({ event }) => {
+    if (event.type === "session.idle") {
+      await $` + "`" + `ding-ding notify -a opencode -m "Task finished"` + "`" + `
+    }
+  },
+})
+`
+	}
+}

--- a/internal/agentsetup/opencode_test.go
+++ b/internal/agentsetup/opencode_test.go
@@ -1,0 +1,84 @@
+package agentsetup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpsertOpenCodePlugin_CreatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".opencode", "plugins", "ding-ding.ts")
+
+	status, err := upsertOpenCodePlugin(path, ModeCLI)
+	if err != nil {
+		t.Fatalf("upsertOpenCodePlugin() error = %v", err)
+	}
+	if status != StatusCreated {
+		t.Fatalf("status = %q, want %q", status, StatusCreated)
+	}
+
+	content := readTextFile(t, path)
+	if !strings.Contains(content, `ding-ding notify -a opencode -m "Task finished"`) {
+		t.Fatalf("unexpected plugin content:\n%s", content)
+	}
+}
+
+func TestUpsertOpenCodePlugin_UpdatesWhenContentDiffers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".opencode", "plugins", "ding-ding.ts")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("// old"), 0o644); err != nil {
+		t.Fatalf("write old file: %v", err)
+	}
+
+	status, err := upsertOpenCodePlugin(path, ModeCLI)
+	if err != nil {
+		t.Fatalf("upsertOpenCodePlugin() error = %v", err)
+	}
+	if status != StatusUpdated {
+		t.Fatalf("status = %q, want %q", status, StatusUpdated)
+	}
+}
+
+func TestUpsertOpenCodePlugin_UnchangedWhenIdentical(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".opencode", "plugins", "ding-ding.ts")
+
+	if _, err := upsertOpenCodePlugin(path, ModeCLI); err != nil {
+		t.Fatalf("initial upsert error = %v", err)
+	}
+	status, err := upsertOpenCodePlugin(path, ModeCLI)
+	if err != nil {
+		t.Fatalf("second upsert error = %v", err)
+	}
+	if status != StatusUnchanged {
+		t.Fatalf("status = %q, want %q", status, StatusUnchanged)
+	}
+}
+
+func TestUpsertOpenCodePlugin_ServerTemplate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".opencode", "plugins", "ding-ding.ts")
+
+	if _, err := upsertOpenCodePlugin(path, ModeServer); err != nil {
+		t.Fatalf("upsert server error = %v", err)
+	}
+
+	content := readTextFile(t, path)
+	if !strings.Contains(content, "localhost:8228/notify") {
+		t.Fatalf("expected curl integration, got:\n%s", content)
+	}
+	if !strings.Contains(content, "process.pid") {
+		t.Fatalf("expected process.pid payload, got:\n%s", content)
+	}
+}
+
+func readTextFile(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %q: %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/agentsetup/paths.go
+++ b/internal/agentsetup/paths.go
@@ -1,0 +1,48 @@
+package agentsetup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var lookupWorkingDir = os.Getwd
+var lookupUserHomeDir = os.UserHomeDir
+
+func ResolveTargetPath(opts Options) (string, error) {
+	if err := opts.Validate(); err != nil {
+		return "", err
+	}
+
+	baseDir := opts.CWD
+	if opts.Scope == ScopeGlobal {
+		baseDir = opts.HomeDir
+	}
+
+	if baseDir == "" {
+		var err error
+		if opts.Scope == ScopeProject {
+			baseDir, err = lookupWorkingDir()
+			if err != nil {
+				return "", fmt.Errorf("resolve project directory: %w", err)
+			}
+		} else {
+			baseDir, err = lookupUserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("resolve home directory: %w", err)
+			}
+		}
+	}
+
+	switch opts.Agent {
+	case AgentClaude:
+		return filepath.Join(baseDir, ".claude", "settings.json"), nil
+	case AgentOpenCode:
+		if opts.Scope == ScopeProject {
+			return filepath.Join(baseDir, ".opencode", "plugins", "ding-ding.ts"), nil
+		}
+		return filepath.Join(baseDir, ".config", "opencode", "plugins", "ding-ding.ts"), nil
+	default:
+		return "", fmt.Errorf("unsupported agent %q", opts.Agent)
+	}
+}

--- a/internal/agentsetup/paths_test.go
+++ b/internal/agentsetup/paths_test.go
@@ -1,0 +1,84 @@
+package agentsetup
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveTargetPath(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+		want string
+	}{
+		{
+			name: "claude project",
+			opts: Options{Agent: AgentClaude, Scope: ScopeProject, Mode: ModeCLI, CWD: "/repo"},
+			want: filepath.Join("/repo", ".claude", "settings.json"),
+		},
+		{
+			name: "claude global",
+			opts: Options{Agent: AgentClaude, Scope: ScopeGlobal, Mode: ModeCLI, HomeDir: "/home/alex"},
+			want: filepath.Join("/home/alex", ".claude", "settings.json"),
+		},
+		{
+			name: "opencode project",
+			opts: Options{Agent: AgentOpenCode, Scope: ScopeProject, Mode: ModeCLI, CWD: "/repo"},
+			want: filepath.Join("/repo", ".opencode", "plugins", "ding-ding.ts"),
+		},
+		{
+			name: "opencode global",
+			opts: Options{Agent: AgentOpenCode, Scope: ScopeGlobal, Mode: ModeCLI, HomeDir: "/home/alex"},
+			want: filepath.Join("/home/alex", ".config", "opencode", "plugins", "ding-ding.ts"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveTargetPath(tt.opts)
+			if err != nil {
+				t.Fatalf("ResolveTargetPath() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveTargetPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTargetPath_HomeLookupFailure(t *testing.T) {
+	orig := lookupUserHomeDir
+	defer func() { lookupUserHomeDir = orig }()
+
+	lookupUserHomeDir = func() (string, error) {
+		return "", errors.New("home unavailable")
+	}
+
+	_, err := ResolveTargetPath(Options{
+		Agent: AgentClaude,
+		Scope: ScopeGlobal,
+		Mode:  ModeCLI,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestResolveTargetPath_WorkingDirLookupFailure(t *testing.T) {
+	orig := lookupWorkingDir
+	defer func() { lookupWorkingDir = orig }()
+
+	lookupWorkingDir = func() (string, error) {
+		return "", errors.New("cwd unavailable")
+	}
+
+	_, err := ResolveTargetPath(Options{
+		Agent: AgentOpenCode,
+		Scope: ScopeProject,
+		Mode:  ModeCLI,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/agentsetup/types.go
+++ b/internal/agentsetup/types.go
@@ -1,0 +1,94 @@
+package agentsetup
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Agent string
+
+const (
+	AgentClaude   Agent = "claude"
+	AgentOpenCode Agent = "opencode"
+)
+
+type Scope string
+
+const (
+	ScopeProject Scope = "project"
+	ScopeGlobal  Scope = "global"
+)
+
+type Mode string
+
+const (
+	ModeCLI    Mode = "cli"
+	ModeServer Mode = "server"
+)
+
+type ChangeStatus string
+
+const (
+	StatusCreated   ChangeStatus = "created"
+	StatusUpdated   ChangeStatus = "updated"
+	StatusUnchanged ChangeStatus = "unchanged"
+)
+
+type Options struct {
+	Agent   Agent
+	Scope   Scope
+	Mode    Mode
+	CWD     string
+	HomeDir string
+}
+
+type Result struct {
+	Path   string
+	Status ChangeStatus
+}
+
+func ParseAgent(value string) (Agent, error) {
+	switch Agent(strings.ToLower(strings.TrimSpace(value))) {
+	case AgentClaude:
+		return AgentClaude, nil
+	case AgentOpenCode:
+		return AgentOpenCode, nil
+	default:
+		return "", fmt.Errorf("invalid agent %q (supported: claude, opencode)", value)
+	}
+}
+
+func ParseScope(value string) (Scope, error) {
+	switch Scope(strings.ToLower(strings.TrimSpace(value))) {
+	case ScopeProject:
+		return ScopeProject, nil
+	case ScopeGlobal:
+		return ScopeGlobal, nil
+	default:
+		return "", fmt.Errorf("invalid scope %q (supported: project, global)", value)
+	}
+}
+
+func ParseMode(value string) (Mode, error) {
+	switch Mode(strings.ToLower(strings.TrimSpace(value))) {
+	case ModeCLI:
+		return ModeCLI, nil
+	case ModeServer:
+		return ModeServer, nil
+	default:
+		return "", fmt.Errorf("invalid mode %q (supported: cli, server)", value)
+	}
+}
+
+func (o Options) Validate() error {
+	if _, err := ParseAgent(string(o.Agent)); err != nil {
+		return err
+	}
+	if _, err := ParseScope(string(o.Scope)); err != nil {
+		return err
+	}
+	if _, err := ParseMode(string(o.Mode)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/agentsetup/upsert.go
+++ b/internal/agentsetup/upsert.go
@@ -1,0 +1,41 @@
+package agentsetup
+
+import "fmt"
+
+func Upsert(opts Options) (Result, error) {
+	agent, err := ParseAgent(string(opts.Agent))
+	if err != nil {
+		return Result{}, err
+	}
+	scope, err := ParseScope(string(opts.Scope))
+	if err != nil {
+		return Result{}, err
+	}
+	mode, err := ParseMode(string(opts.Mode))
+	if err != nil {
+		return Result{}, err
+	}
+	opts.Agent = agent
+	opts.Scope = scope
+	opts.Mode = mode
+
+	path, err := ResolveTargetPath(opts)
+	if err != nil {
+		return Result{}, err
+	}
+
+	var status ChangeStatus
+	switch opts.Agent {
+	case AgentClaude:
+		status, err = upsertClaudeSettings(path, opts.Mode)
+	case AgentOpenCode:
+		status, err = upsertOpenCodePlugin(path, opts.Mode)
+	default:
+		return Result{}, fmt.Errorf("unsupported agent %q", opts.Agent)
+	}
+	if err != nil {
+		return Result{}, err
+	}
+
+	return Result{Path: path, Status: status}, nil
+}

--- a/internal/agentsetup/upsert_test.go
+++ b/internal/agentsetup/upsert_test.go
@@ -1,0 +1,89 @@
+package agentsetup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpsert_ClaudeProject(t *testing.T) {
+	cwd := t.TempDir()
+
+	result, err := Upsert(Options{
+		Agent: AgentClaude,
+		Scope: ScopeProject,
+		Mode:  ModeCLI,
+		CWD:   cwd,
+	})
+	if err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	wantPath := filepath.Join(cwd, ".claude", "settings.json")
+	if result.Path != wantPath {
+		t.Fatalf("result.Path = %q, want %q", result.Path, wantPath)
+	}
+	if result.Status != StatusCreated {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusCreated)
+	}
+
+	result, err = Upsert(Options{
+		Agent: AgentClaude,
+		Scope: ScopeProject,
+		Mode:  ModeCLI,
+		CWD:   cwd,
+	})
+	if err != nil {
+		t.Fatalf("second Upsert() error = %v", err)
+	}
+	if result.Status != StatusUnchanged {
+		t.Fatalf("second result.Status = %q, want %q", result.Status, StatusUnchanged)
+	}
+}
+
+func TestUpsert_OpenCodeGlobal(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Upsert(Options{
+		Agent:   AgentOpenCode,
+		Scope:   ScopeGlobal,
+		Mode:    ModeCLI,
+		HomeDir: home,
+	})
+	if err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	wantPath := filepath.Join(home, ".config", "opencode", "plugins", "ding-ding.ts")
+	if result.Path != wantPath {
+		t.Fatalf("result.Path = %q, want %q", result.Path, wantPath)
+	}
+	if result.Status != StatusCreated {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusCreated)
+	}
+}
+
+func TestUpsert_PropagatesClaudeParseError(t *testing.T) {
+	cwd := t.TempDir()
+	path := filepath.Join(cwd, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{ invalid"), 0o644); err != nil {
+		t.Fatalf("write invalid settings: %v", err)
+	}
+
+	_, err := Upsert(Options{
+		Agent: AgentClaude,
+		Scope: ScopeProject,
+		Mode:  ModeCLI,
+		CWD:   cwd,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse claude settings") {
+		t.Fatalf("error = %q, want parse context", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `ding-ding agent init/update` commands for Claude and OpenCode setup
- tighten Claude managed-hook detection to exact, event-specific matching
- drop empty hook entries after managed-hook cleanup to avoid orphaned blocks
- add regression tests for custom server hooks and matcher entry cleanup/preservation

## Testing
- go test ./...
- go test -race ./...
- go vet ./...
