### PR TITLE
fix(focus): scope multiplexer focus checks to active session

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ sending any remote notifications (ntfy, Discord, etc). With async, Claude return
 The `$$` sends the shell's PID so the server can check if the agent's terminal is focused.
 Start the server separately with `ding-ding serve`.
 
+On macOS, focus detection includes multiplexer-aware fallback for `zellij` and
+`tmux` sessions. If multiplexer focus cannot be determined reliably, ding-ding
+defaults to suppression (treats focus as uncertain rather than unfocused) to
+avoid noisy false-positive notifications.
+
 #### OpenCode
 
 Use the setup command (recommended):
@@ -327,7 +332,7 @@ Focused  Unfocused    Idle
 |---------|-------|-------|---------|
 | System notifications | `notify-send` | `osascript` | PowerShell toast |
 | Idle detection | `xprintidle` / DBus | `ioreg` | `GetLastInputInfo` |
-| Focus detection | `xdotool` / `kdotool` | `osascript` | `GetForegroundWindow` |
+| Focus detection | `xdotool` / `kdotool` | `osascript` + multiplexer-aware fallback (`zellij`, `tmux`) | `GetForegroundWindow` |
 | ntfy / Discord / Webhook | ✓ | ✓ | ✓ |
 
 ## Maintainer Quality Gate

--- a/internal/focus/focus_darwin_multiplexer.go
+++ b/internal/focus/focus_darwin_multiplexer.go
@@ -1,0 +1,120 @@
+//go:build darwin
+
+package focus
+
+import "strings"
+
+func zellijFocusState(sessionName string, focusedPID int) (bool, bool) {
+	procs, err := processListFunc()
+	if err != nil {
+		return false, false
+	}
+
+	for _, proc := range procs {
+		if !isZellijClientProcess(proc) {
+			continue
+		}
+		if !zellijSessionMatches(proc.Args, sessionName) {
+			continue
+		}
+		if isAncestor(focusedPID, proc.PID) {
+			return true, true
+		}
+	}
+
+	return false, true
+}
+
+func isZellijClientProcess(proc processInfo) bool {
+	if !strings.EqualFold(proc.Comm, "zellij") {
+		return false
+	}
+	return !isZellijServerProcess(proc.Args)
+}
+
+func isZellijServerProcess(args string) bool {
+	for _, token := range strings.Fields(args) {
+		if token == "--server" || strings.HasPrefix(token, "--server=") {
+			return true
+		}
+	}
+	return false
+}
+
+func zellijSessionMatches(args string, sessionName string) bool {
+	if sessionName == "" {
+		return false
+	}
+
+	fields := strings.Fields(args)
+	for i := 0; i < len(fields); i++ {
+		token := fields[i]
+		switch {
+		case token == "-s" || token == "--session":
+			if i+1 < len(fields) && fields[i+1] == sessionName {
+				return true
+			}
+		case strings.HasPrefix(token, "-s="):
+			if strings.TrimPrefix(token, "-s=") == sessionName {
+				return true
+			}
+		case strings.HasPrefix(token, "--session="):
+			if strings.TrimPrefix(token, "--session=") == sessionName {
+				return true
+			}
+		case (token == "attach" || token == "a") && i+1 < len(fields):
+			if fields[i+1] == sessionName {
+				return true
+			}
+		}
+	}
+
+	// Strict fallback: avoid substring matching session names (e.g. "dev" in
+	// "dev2"), which can incorrectly mark unrelated sessions as focused.
+	for _, token := range fields {
+		if token == sessionName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func tmuxFocusState(tmuxEnv string, focusedPID int) (bool, bool) {
+	socketPath, sessionID, ok := tmuxSocketAndSession(tmuxEnv)
+	if !ok {
+		return false, false
+	}
+
+	clientPIDs, err := tmuxClientPIDsFn(socketPath, sessionID)
+	if err != nil {
+		return false, false
+	}
+
+	for _, clientPID := range clientPIDs {
+		if isAncestor(focusedPID, clientPID) {
+			return true, true
+		}
+	}
+
+	return false, true
+}
+
+func tmuxSocketAndSession(tmuxEnv string) (string, string, bool) {
+	parts := strings.Split(strings.TrimSpace(tmuxEnv), ",")
+	if len(parts) < 3 {
+		return "", "", false
+	}
+
+	socketPath := strings.TrimSpace(parts[0])
+	sessionID := normalizeTMUXSessionID(parts[2])
+	if socketPath == "" || sessionID == "" {
+		return "", "", false
+	}
+
+	return socketPath, sessionID, true
+}
+
+func normalizeTMUXSessionID(sessionID string) string {
+	return strings.TrimPrefix(strings.TrimSpace(sessionID), "$")
+}

--- a/internal/focus/focus_darwin_probe.go
+++ b/internal/focus/focus_darwin_probe.go
@@ -1,0 +1,227 @@
+//go:build darwin
+
+package focus
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type processInfo struct {
+	PID  int
+	PPID int
+	Comm string
+	Args string
+}
+
+var (
+	osascriptOutputFunc = func() ([]byte, error) {
+		return exec.Command("osascript", "-e", frontmostPIDAppleScript).Output()
+	}
+	psEnvOutputFunc = func(pid int) ([]byte, error) {
+		return exec.Command("ps", "eww", "-p", strconv.Itoa(pid)).Output()
+	}
+	psProcessListOutputFunc = func() ([]byte, error) {
+		return exec.Command("ps", "-axo", "pid=,ppid=,comm=,args=").Output()
+	}
+	tmuxListClientsOutputFunc = func(socketPath string) ([]byte, error) {
+		return exec.Command("tmux", "-S", socketPath, "list-clients", "-F", "#{session_id} #{client_pid}").Output()
+	}
+)
+
+func processEnv(pid int) (map[string]string, error) {
+	out, err := psEnvOutputFunc(pid)
+	if err != nil {
+		return nil, err
+	}
+	return parsePSEnvironmentOutput(out)
+}
+
+func parsePSEnvironmentOutput(out []byte) (map[string]string, error) {
+	lines := strings.Split(string(out), "\n")
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+
+		// Skip header and wrapped continuation rows that do not start with PID.
+		if _, err := strconv.Atoi(fields[0]); err != nil {
+			continue
+		}
+
+		env := make(map[string]string)
+		for _, token := range fields[1:] {
+			key, value, ok := strings.Cut(token, "=")
+			if !ok || !isEnvKey(key) {
+				continue
+			}
+			env[key] = value
+		}
+		return env, nil
+	}
+
+	return nil, fmt.Errorf("ps eww output missing process row")
+}
+
+func isEnvKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i, r := range key {
+		switch {
+		case r == '_':
+			continue
+		case unicode.IsLetter(r):
+			continue
+		case i > 0 && unicode.IsDigit(r):
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func processList() ([]processInfo, error) {
+	out, err := psProcessListOutputFunc()
+	if err != nil {
+		return nil, err
+	}
+	return parseProcessListOutput(out)
+}
+
+func parseProcessListOutput(out []byte) ([]processInfo, error) {
+	lines := strings.Split(string(out), "\n")
+	procs := make([]processInfo, 0, len(lines))
+
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+
+		proc, err := parseProcessListLine(line)
+		if err != nil {
+			return nil, err
+		}
+		procs = append(procs, proc)
+	}
+
+	if len(procs) == 0 {
+		return nil, fmt.Errorf("ps process list output is empty")
+	}
+
+	return procs, nil
+}
+
+func parseProcessListLine(line string) (processInfo, error) {
+	pidField, rest, ok := nextField(line)
+	if !ok {
+		return processInfo{}, fmt.Errorf("missing pid field")
+	}
+	ppidField, rest, ok := nextField(rest)
+	if !ok {
+		return processInfo{}, fmt.Errorf("missing ppid field")
+	}
+	comm, rest, ok := nextField(rest)
+	if !ok {
+		return processInfo{}, fmt.Errorf("missing comm field")
+	}
+
+	pid, err := strconv.Atoi(pidField)
+	if err != nil || pid <= 0 {
+		return processInfo{}, fmt.Errorf("invalid pid %q", pidField)
+	}
+	ppid, err := strconv.Atoi(ppidField)
+	if err != nil || ppid < 0 {
+		return processInfo{}, fmt.Errorf("invalid ppid %q", ppidField)
+	}
+
+	return processInfo{
+		PID:  pid,
+		PPID: ppid,
+		Comm: comm,
+		Args: strings.TrimSpace(rest),
+	}, nil
+}
+
+func nextField(input string) (field string, rest string, ok bool) {
+	s := strings.TrimLeft(input, " \t")
+	if s == "" {
+		return "", "", false
+	}
+
+	i := 0
+	for i < len(s) && s[i] != ' ' && s[i] != '\t' {
+		i++
+	}
+	if i == 0 {
+		return "", "", false
+	}
+
+	return s[:i], s[i:], true
+}
+
+func tmuxClientPIDs(socketPath string, sessionID string) ([]int, error) {
+	out, err := tmuxListClientsOutputFunc(socketPath)
+	if err != nil {
+		return nil, err
+	}
+	return parseTMUXClientPIDOutput(out, sessionID)
+}
+
+func parseTMUXClientPIDOutput(out []byte, sessionID string) ([]int, error) {
+	sessionID = normalizeTMUXSessionID(sessionID)
+	if sessionID == "" {
+		return nil, fmt.Errorf("tmux session id is empty")
+	}
+
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	pids := make([]int, 0, len(lines))
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("invalid tmux client row %q", line)
+		}
+
+		rowSessionID := normalizeTMUXSessionID(fields[0])
+		pid, err := strconv.Atoi(fields[1])
+		if err != nil || pid <= 0 {
+			return nil, fmt.Errorf("invalid tmux client pid %q", fields[1])
+		}
+
+		if rowSessionID != sessionID {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+
+	return pids, nil
+}
+
+func parentPID(pid int) (int, error) {
+	out, err := exec.Command("ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(out)))
+}

--- a/internal/focus/focus_darwin_test.go
+++ b/internal/focus/focus_darwin_test.go
@@ -1,0 +1,264 @@
+//go:build darwin
+
+package focus
+
+import (
+	"errors"
+	"testing"
+)
+
+func setupDarwinFocusStubs(t *testing.T) {
+	t.Helper()
+
+	origFrontmost := frontmostPIDFunc
+	origEnv := processEnvFunc
+	origList := processListFunc
+	origTmuxClients := tmuxClientPIDsFn
+
+	t.Cleanup(func() {
+		frontmostPIDFunc = origFrontmost
+		processEnvFunc = origEnv
+		processListFunc = origList
+		tmuxClientPIDsFn = origTmuxClients
+	})
+}
+
+func TestProcessInFocusedTerminalState_DirectAncestor(t *testing.T) {
+	setupDarwinFocusStubs(t)
+	setupParentPIDStub(t, map[int]int{
+		100: 200,
+	})
+
+	frontmostPIDFunc = func() (int, bool) { return 200, true }
+
+	envCalled := false
+	processEnvFunc = func(pid int) (map[string]string, error) {
+		envCalled = true
+		return map[string]string{}, nil
+	}
+
+	focused, known := processInFocusedTerminalState(100)
+	if !focused || !known {
+		t.Fatalf("got focused=%v known=%v, want focused=true known=true", focused, known)
+	}
+	if envCalled {
+		t.Fatal("expected processEnv lookup to be skipped on direct ancestor match")
+	}
+}
+
+func TestProcessInFocusedTerminalState_ZellijFocusedSession(t *testing.T) {
+	setupDarwinFocusStubs(t)
+	setupParentPIDStub(t, map[int]int{
+		100:  50, // target process chain does not include focused PID
+		50:   1,
+		300:  999, // zellij client process is under focused app
+		999:  1,
+		3000: 1,
+	})
+
+	frontmostPIDFunc = func() (int, bool) { return 999, true }
+	processEnvFunc = func(pid int) (map[string]string, error) {
+		return map[string]string{"ZELLIJ_SESSION_NAME": "cyphant_homepage"}, nil
+	}
+	processListFunc = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 3000, Comm: "zellij", Args: "zellij --server /tmp/socket"},
+			{PID: 300, Comm: "zellij", Args: "zellij -s cyphant_homepage"},
+		}, nil
+	}
+
+	focused, known := processInFocusedTerminalState(100)
+	if !focused || !known {
+		t.Fatalf("got focused=%v known=%v, want focused=true known=true", focused, known)
+	}
+}
+
+func TestProcessInFocusedTerminalState_ZellijSessionMismatch(t *testing.T) {
+	setupDarwinFocusStubs(t)
+	setupParentPIDStub(t, map[int]int{
+		100: 20,
+		20:  1,
+		300: 999,
+		999: 1,
+	})
+
+	frontmostPIDFunc = func() (int, bool) { return 999, true }
+	processEnvFunc = func(pid int) (map[string]string, error) {
+		return map[string]string{"ZELLIJ_SESSION_NAME": "cyphant_homepage"}, nil
+	}
+	processListFunc = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 300, Comm: "zellij", Args: "zellij -s other_session"},
+		}, nil
+	}
+
+	focused, known := processInFocusedTerminalState(100)
+	if focused || !known {
+		t.Fatalf("got focused=%v known=%v, want focused=false known=true", focused, known)
+	}
+}
+
+func TestProcessInFocusedTerminalState_ZellijProbeFailureIsUncertain(t *testing.T) {
+	setupDarwinFocusStubs(t)
+	setupParentPIDStub(t, map[int]int{
+		100: 20,
+		20:  1,
+		999: 1,
+	})
+
+	frontmostPIDFunc = func() (int, bool) { return 999, true }
+	processEnvFunc = func(pid int) (map[string]string, error) {
+		return map[string]string{"ZELLIJ_SESSION_NAME": "cyphant_homepage"}, nil
+	}
+	processListFunc = func() ([]processInfo, error) {
+		return nil, errors.New("ps failed")
+	}
+
+	focused, known := processInFocusedTerminalState(100)
+	if focused || known {
+		t.Fatalf("got focused=%v known=%v, want focused=false known=false", focused, known)
+	}
+}
+
+func TestProcessInFocusedTerminalState_TmuxFocusedClient(t *testing.T) {
+	setupDarwinFocusStubs(t)
+	setupParentPIDStub(t, map[int]int{
+		100: 20,
+		20:  1,
+		700: 999, // tmux client pid under focused app
+		999: 1,
+	})
+
+	frontmostPIDFunc = func() (int, bool) { return 999, true }
+	processEnvFunc = func(pid int) (map[string]string, error) {
+		return map[string]string{"TMUX": "/tmp/tmux-501/default,123,0"}, nil
+	}
+	tmuxClientPIDsFn = func(socketPath string, sessionID string) ([]int, error) {
+		if socketPath != "/tmp/tmux-501/default" {
+			t.Fatalf("socketPath=%q, want %q", socketPath, "/tmp/tmux-501/default")
+		}
+		if sessionID != "0" {
+			t.Fatalf("sessionID=%q, want %q", sessionID, "0")
+		}
+		return []int{700}, nil
+	}
+
+	focused, known := processInFocusedTerminalState(100)
+	if !focused || !known {
+		t.Fatalf("got focused=%v known=%v, want focused=true known=true", focused, known)
+	}
+}
+
+func TestProcessInFocusedTerminalState_TmuxUnfocused(t *testing.T) {
+	setupDarwinFocusStubs(t)
+	setupParentPIDStub(t, map[int]int{
+		100: 20,
+		20:  1,
+		700: 2, // tmux client pid is not under focused app
+		2:   1,
+		999: 1,
+	})
+
+	frontmostPIDFunc = func() (int, bool) { return 999, true }
+	processEnvFunc = func(pid int) (map[string]string, error) {
+		return map[string]string{"TMUX": "/tmp/tmux-501/default,123,0"}, nil
+	}
+	tmuxClientPIDsFn = func(socketPath string, sessionID string) ([]int, error) {
+		return []int{700}, nil
+	}
+
+	focused, known := processInFocusedTerminalState(100)
+	if focused || !known {
+		t.Fatalf("got focused=%v known=%v, want focused=false known=true", focused, known)
+	}
+}
+
+func TestProcessInFocusedTerminalState_TmuxQueryFailureIsUncertain(t *testing.T) {
+	setupDarwinFocusStubs(t)
+	setupParentPIDStub(t, map[int]int{
+		100: 20,
+		20:  1,
+		999: 1,
+	})
+
+	frontmostPIDFunc = func() (int, bool) { return 999, true }
+	processEnvFunc = func(pid int) (map[string]string, error) {
+		return map[string]string{"TMUX": "/tmp/tmux-501/default,123,0"}, nil
+	}
+	tmuxClientPIDsFn = func(socketPath string, sessionID string) ([]int, error) {
+		return nil, errors.New("tmux failed")
+	}
+
+	focused, known := processInFocusedTerminalState(100)
+	if focused || known {
+		t.Fatalf("got focused=%v known=%v, want focused=false known=false", focused, known)
+	}
+}
+
+func TestParsePSEnvironmentOutput_ExtractsMultiplexerVars(t *testing.T) {
+	out := []byte(`  PID   TT  STAT      TIME COMMAND
+17223 s008  S+     0:00.00 claude ZELLIJ_SESSION_NAME=cyphant_homepage TMUX=/tmp/tmux-501/default,123,0 PATH=/usr/bin
+`)
+
+	env, err := parsePSEnvironmentOutput(out)
+	if err != nil {
+		t.Fatalf("parsePSEnvironmentOutput() error = %v", err)
+	}
+
+	if env["ZELLIJ_SESSION_NAME"] != "cyphant_homepage" {
+		t.Fatalf("ZELLIJ_SESSION_NAME=%q, want %q", env["ZELLIJ_SESSION_NAME"], "cyphant_homepage")
+	}
+	if env["TMUX"] != "/tmp/tmux-501/default,123,0" {
+		t.Fatalf("TMUX=%q, want %q", env["TMUX"], "/tmp/tmux-501/default,123,0")
+	}
+}
+
+func TestParseProcessListOutput(t *testing.T) {
+	out := []byte(`
+16734 47930 zellij zellij -s cyphant_homepage
+16737 1 zellij /opt/homebrew/bin/zellij --server /tmp/socket
+`)
+
+	procs, err := parseProcessListOutput(out)
+	if err != nil {
+		t.Fatalf("parseProcessListOutput() error = %v", err)
+	}
+	if len(procs) != 2 {
+		t.Fatalf("process count = %d, want 2", len(procs))
+	}
+	if procs[0].PID != 16734 || procs[0].PPID != 47930 {
+		t.Fatalf("first process = %+v, want pid=16734 ppid=47930", procs[0])
+	}
+	if procs[1].Args == "" {
+		t.Fatal("expected args to be parsed for second process")
+	}
+}
+
+func TestParseTMUXClientPIDOutput(t *testing.T) {
+	pids, err := parseTMUXClientPIDOutput([]byte("$0 100\n$1 200\n$0 300\n"), "0")
+	if err != nil {
+		t.Fatalf("parseTMUXClientPIDOutput() error = %v", err)
+	}
+	if len(pids) != 2 || pids[0] != 100 || pids[1] != 300 {
+		t.Fatalf("pids = %#v, want []int{100,300}", pids)
+	}
+}
+
+func TestZellijSessionMatches_DoesNotAllowSubstringMatch(t *testing.T) {
+	if zellijSessionMatches("zellij -s dev2", "dev") {
+		t.Fatal("expected false for substring-only session match")
+	}
+}
+
+func TestTMUXSocketAndSession(t *testing.T) {
+	socketPath, sessionID, ok := tmuxSocketAndSession("/tmp/tmux-501/default,123,$4")
+	if !ok {
+		t.Fatal("expected tmux socket/session parse to succeed")
+	}
+	if socketPath != "/tmp/tmux-501/default" {
+		t.Fatalf("socketPath=%q, want %q", socketPath, "/tmp/tmux-501/default")
+	}
+	if sessionID != "4" {
+		t.Fatalf("sessionID=%q, want %q", sessionID, "4")
+	}
+}


### PR DESCRIPTION
## Summary
- scope tmux focus detection to the active tmux session from 
- tighten zellij session matching to avoid substring false positives across similarly named sessions
- add/adjust darwin focus tests for session parsing and matching behavior

## Validation
- go test ./internal/focus
- go test ./...